### PR TITLE
`Integrals`: add Simpson's 1/3 rule

### DIFF
--- a/src/derivatives.rs
+++ b/src/derivatives.rs
@@ -1,9 +1,11 @@
 //! This module implements numerical derivatives algorithms.
 //!
-//! For now, it only contains the `Derivative` struct with a single method `forward_difference`, which performs numerical
-//! differentiation using finite differences.
+//! It contains the `Derivative` struct, with three methods which perform numerical differentiation:
+//! - `forward_difference`: Uses the forward difference method to approximate the derivative of a function at a specified point.
+//! - `backward_difference`: Uses the backward difference method to approximate the derivative of a function at a specified point.
+//! - `central_difference`: Uses the central difference method to approximate the derivative of a function at a specified point.
 
-type Function = Box<dyn Fn(f64) -> f64>;
+type Function = Box<dyn Fn(f64) -> f64>; // TODO: GS consider using a trait object instead of a function pointer, or commonise the type definition since it is used in both `integrals` and `derivatives` modules
 
 /// A struct that provides numerical differentiation methods.
 pub struct Derivative {

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ fn call_integrals() {
 
         // Perform numerical integration using the Integral struct
         let res =
-            Integral::new(Box::new(func), lower_bound, upper_bound, num_intervals).integrate();
+            Integral::new(Box::new(func), lower_bound, upper_bound, num_intervals).riemann_integration();
 
         // Print the result of the integration
         println!("The result of the integral is: {}", res);


### PR DESCRIPTION
- Added Simpson's 1/3 rule to the `integrals` module.
- Updated the tests accordingly, so that both rules are tested for each mathematical function under test.
- Updated the `main.rs` accordingly.
- Updated comments and documentation.
- Closes #18.